### PR TITLE
Add description and document in metadata

### DIFF
--- a/docs/model/AU.html
+++ b/docs/model/AU.html
@@ -274,6 +274,15 @@
     <main class="mdl-layout__content mdl-color--grey-100">
       <div id="content" class="content">
         
+<div class="mdl-card mdl-shadow--2dp" style="width: 95%; margin: 8px">
+  <div class="mdl-card__title">
+    <h2 class="mdl-card__title-text">About the country</h2>
+  </div>
+  <div class="mdl-card__actions mdl-card--border">
+    <div style="margin: 8px">Addresses in Australia typically follow the structure described in the following <a href="https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-addressing-standards-1999.pdf" > DOCUMENT</a>.</div>
+  </div>
+</div>
+
 
 
 
@@ -532,7 +541,7 @@
     
     
     <a href="#building">building</a>
-    - House number (in a street or block) or name of a building.
+    - House number
       
         
       
@@ -654,7 +663,7 @@
     
     
     <a href="#locality1">locality1</a>
-    - Biggest sub type of a locality, often a city
+    - City/Suburb
       
         
       
@@ -1475,7 +1484,7 @@ Name of a street
 </h3>
 <div style="margin-left: 20px;">
 
-House number (in a street or block) or name of a building.
+House number
 
 
 
@@ -1575,7 +1584,7 @@ Identifier of a unit (e.g. &#34;5&#34;)
 </h3>
 <div style="margin-left: 20px;">
 
-Biggest sub type of a locality, often a city
+City/Suburb
 
 
 

--- a/model/countries/AU/AU-descriptions.yaml
+++ b/model/countries/AU/AU-descriptions.yaml
@@ -1,0 +1,3 @@
+short-descriptions:
+  locality1: City/Suburb
+  building: House number

--- a/model/countries/AU/AU-metadata.yaml
+++ b/model/countries/AU/AU-metadata.yaml
@@ -1,2 +1,6 @@
 country: AU
 flag: 🇦🇺
+
+
+overview: |
+    Addresses in Australia typically follow the structure described in the following <a href="https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-addressing-standards-1999.pdf" > DOCUMENT</a>.


### PR DESCRIPTION
This PR adds a description for building and locality1 as well as a link to the document which contains the detailed description of addresses in AU.