### PR TITLE
Add formatting rules for Poland DM

### DIFF
--- a/docs/model/PL.html
+++ b/docs/model/PL.html
@@ -1217,6 +1217,305 @@ The whole node of street-address for Poland in redundant, since the data is stor
     <div>&nbsp;</div>
     
   </div>
+</div>
+
+<div class="mdl-card mdl-shadow--2dp" style="width: 95%; margin: 8px">
+  <div class="mdl-card__title">
+    <h2 class="mdl-card__title-text">Example addresses</h2>
+  </div>
+  <div class="mdl-card__actions mdl-card--border">
+    <table class="formatting_example_overview_table">
+      
+      
+<tr>
+  <td colspan="2">
+    <b>name</b>: This is an example of a name.
+
+  </td>
+</tr>
+<tr>
+  <th>Input</th>
+  <th>Output</th>
+</tr>
+<tr>
+  <td valign="top">
+    <table>
+      
+        
+      
+        
+      
+        
+        <tr>
+          <td>given-name</td><td><pre style="margin:0">Jan</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+        <tr>
+          <td>family-name</td><td><pre style="margin:0">Kowalski</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    </table>
+  </td>
+  <td valign="top">
+    
+      Output for "name":<br>
+      <pre class="formatting_example_textbox">Jan Kowalski</pre>
+      
+      
+    
+  </td>
+</tr>
+<tr>
+  <td span="2">
+    &nbsp;
+  </td>
+</tr>
+
+      
+      
+<tr>
+  <td colspan="2">
+    <b>address</b>: This is an example of a full address in Poland.
+
+  </td>
+</tr>
+<tr>
+  <th>Input</th>
+  <th>Output</th>
+</tr>
+<tr>
+  <td valign="top">
+    <table>
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+        <tr>
+          <td>street</td><td><pre style="margin:0">ul. Warsaw</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building-and-unit</td><td><pre style="margin:0">9/10</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building</td><td><pre style="margin:0">9</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>unit</td><td><pre style="margin:0">10</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>locality1</td><td><pre style="margin:0">Warsaw</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+        <tr>
+          <td>postal-code</td><td><pre style="margin:0">01-001</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country</td><td><pre style="margin:0">PL</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country-name</td><td><pre style="margin:0">Polska</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    </table>
+  </td>
+  <td valign="top">
+    
+      Output for "address":<br>
+      <pre class="formatting_example_textbox">ul. Warsaw 9/10
+01-001 Warsaw
+Polska</pre>
+      
+      
+    
+  </td>
+</tr>
+<tr>
+  <td span="2">
+    &nbsp;
+  </td>
+</tr>
+
+      
+    </table>
+  </div>
 </div><div class="mdl-card mdl-shadow--2dp" style="width: 95%; margin: 8px">
   <div class="mdl-card__title">
     <h2 class="mdl-card__title-text">Details</h2>
@@ -1258,6 +1557,24 @@ Full name
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">name</span> =
+<span class="formatting_token">honorific-prefix</span><span class="formatting_token">given-name</span><span class="formatting_token">additional-name</span><span class="formatting_token">family-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">name</span> =<br>
+<span class="formatting_token">honorific-prefix</span><span class="formatting_token">given-name</span><span class="formatting_token">additional-name</span><span class="formatting_token">family-name</span>
 </div>
 
 </div><h3 id="honorific-prefix">
@@ -1357,6 +1674,24 @@ Address of a physical location - Artificial concept, not to be used in HTML
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">address</span> =
+<span class="formatting_token">street-address-alternative-1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">country-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">address</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
+</div>
+
 </div><h3 id="street-address">
   <a href="#street-address">#</a>
   
@@ -1393,6 +1728,24 @@ Street address (street and location within the street)
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">street-address</span> =
+<span class="formatting_token">address-line1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line2</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line3</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line4</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">street-address</span> =<br>
+<span class="formatting_token">address-line1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line2</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line3</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line4</span>
 </div>
 
 </div><h3 id="address-line1">
@@ -1463,6 +1816,24 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">street-address-alternative-1</span> =
+<span class="formatting_token">building-location</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">street-address-alternative-1</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
+</div>
+
 </div><h3 id="building-location">
   <a href="#building-location">#</a>
   
@@ -1489,6 +1860,24 @@ Name of a street and identifier for the building and the apartment
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">building-location</span> =
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building-and-unit</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">building-location</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
 </div>
 
 </div><h3 id="street">
@@ -1528,6 +1917,24 @@ House number and apartment number
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">building-and-unit</span> =
+<span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">building-and-unit</span> =<br>
+<span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
 </div>
 
 </div><h3 id="building">
@@ -1699,6 +2106,24 @@ Full name of credit card holder
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-name</span> =
+<span class="formatting_token">cc-given-name</span><span class="formatting_token">cc-additional-name</span><span class="formatting_token">cc-family-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-name</span> =<br>
+<span class="formatting_token">cc-given-name</span><span class="formatting_token">cc-additional-name</span><span class="formatting_token">cc-family-name</span>
+</div>
+
 </div><h3 id="cc-given-name">
   <a href="#cc-given-name">#</a>
   
@@ -1771,6 +2196,24 @@ Credit card expiration date in format MM/YY
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-exp-MMYY</span> =
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YY</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-exp-MMYY</span> =<br>
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YY</span>
+</div>
+
 </div><h3 id="cc-exp-MM">
   <a href="#cc-exp-MM">#</a>
   
@@ -1819,6 +2262,24 @@ Credit card expiration date in format MM/YYYY
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-exp-MMYYYY</span> =
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YYYY</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-exp-MMYYYY</span> =<br>
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YYYY</span>
 </div>
 
 </div><h3 id="cc-exp-YYYY">
@@ -1887,6 +2348,24 @@ Full telephone number
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel</span> =
+<span class="formatting_token_prefix">+</span><span class="formatting_token">tel-country-code</span><span class="formatting_token">tel-national</span><span class="formatting_token_separator">-</span><span class="formatting_token">tel-extension</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel</span> =<br>
+<span class="formatting_token_prefix">+</span><span class="formatting_token">tel-country-code</span><span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span><span class="formatting_token_separator">-</span><span class="formatting_token">tel-extension</span>
+</div>
+
 </div><h3 id="tel-country-code">
   <a href="#tel-country-code">#</a>
   
@@ -1925,6 +2404,24 @@ Telephone number without the county code component, with a country-internal pref
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel-national</span> =
+<span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel-national</span> =<br>
+<span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
 </div>
 
 </div><h3 id="tel-area-code">
@@ -1966,6 +2463,24 @@ Telephone number without the country code and area code components
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel-local</span> =
+<span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel-local</span> =<br>
+<span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
 </div>
 
 </div><h3 id="tel-local-prefix">

--- a/model/countries/PL/PL-formatting-rules.yaml
+++ b/model/countries/PL/PL-formatting-rules.yaml
@@ -1,0 +1,58 @@
+formatting-rules:
+  address:
+  - street-address-alternative-1
+  - separator: "\n"
+  - postal-code
+  - separator: " "
+  - locality1
+  - separator: "\n"
+  - country-name
+  - skip: country  # redundant with country-name
+  - skip: street-address  # redundant with street-address-alternative-1
+  - skip: admin-area1
+
+  street-address-alternative-1:
+  - building-location
+
+  building-location:
+  - street
+  - separator: " "
+  - building-and-unit
+
+  building-and-unit:
+  - building
+  - separator: "/"
+  - unit
+
+examples:
+- id: name
+  comment: |
+    This is an example of a name.
+  attributes:
+    given-name: Jan
+    family-name: Kowalski
+  output:
+    name:
+      show: true
+      text: Jan Kowalski
+
+- id: address
+  comment: |
+    This is an example of a full address in Poland.
+  attributes:
+    street: ul. Warsaw
+    building: 9
+    unit: 10
+    building-and-unit: 9/10
+    locality1: Warsaw
+    postal-code: 01-001
+    country: PL
+    country-name: Polska
+
+  output:
+    address:
+      show: true
+      text: |
+        ul. Warsaw 9/10
+        01-001 Warsaw
+        Polska


### PR DESCRIPTION
Add formatting rules for Poland data model.

Currently, covering the formatting which includes building number separation with apartment number by slash.
PTAL examples in formatting-rules file.