### PR TITLE
Add Parsing Rules for PL DM

### DIFF
--- a/docs/model/PL.html
+++ b/docs/model/PL.html
@@ -646,6 +646,45 @@ The whole node of street-address for Poland in redundant, since the data is stor
     
   </div>
   
+    
+    
+      <div class="concept-content">
+        
+          
+<div class="concept">
+  <div class="concept-id">
+    
+    
+    <a href="#unit-type">unit-type</a>
+    - Type of a unit (e.g. &#34;Apt&#34;, &#34;Room&#34;, &#34;Store&#34;)
+      
+        
+      
+    
+  </div>
+  
+</div>
+
+        
+          
+<div class="concept">
+  <div class="concept-id">
+    
+    
+    <a href="#unit-name">unit-name</a>
+    - Identifier of a unit (e.g. &#34;5&#34;)
+      
+        
+      
+    
+  </div>
+  
+</div>
+
+        
+      </div>
+    
+  
 </div>
 
         
@@ -1339,6 +1378,10 @@ The whole node of street-address for Poland in redundant, since the data is stor
       
         
       
+        
+      
+        
+      
     </table>
   </td>
   <td valign="top">
@@ -1420,6 +1463,10 @@ The whole node of street-address for Poland in redundant, since the data is stor
         <tr>
           <td>unit</td><td><pre style="margin:0">10</pre></td>
         </tr>
+        
+      
+        
+      
         
       
         
@@ -1532,6 +1579,1699 @@ Full name
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h4>Parsing:</h4>
+<div class="parsing">
+
+
+
+
+<details>
+  <summary>Decomposition Cascade
+  
+  </summary>
+  
+  Cascade:<br>
+  <ol>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition Cascade
+  
+  (if <code>kHasCjkNameCharacteristics</code>)
+  
+  </summary>
+  
+  Condition:<br>
+  
+
+
+
+<details>
+  <summary>Regex Reference: <code>kHasCjkNameCharacteristics</code></summary>
+  
+
+
+  Regex concatenation
+  <ol>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">^</code>
+
+
+</li>
+    
+    <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">(?:</code>
+
+
+</li>
+    
+    <li>
+
+
+
+  Regex Reference: <code>kCjkNameSeperatorsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:・|·|　|\s+)</code>
+
+
+
+</li>
+    
+    <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">)?$</code>
+
+
+</li>
+    
+  </ol>
+  Wrap as non-capture group: True
+
+
+
+</details>
+
+
+
+<br>
+  
+  Cascade:<br>
+  <ol>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseSeparatedCjkNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseSeparatedCjkNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kCjkNameSeperatorsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:・|·|　|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseKoreanTwoCharacterLastNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseKoreanTwoCharacterLastNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kTwoCharacterKoreanNamesRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:강전|남궁|독고|동방|망절|사공|서문|선우|소봉|어금|장곡|제갈|황목|황보)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHangulCharacterRe</code> =&gt;
+  <code class="parsing-regexfragment">\p{Hangul}</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHangulCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">\p{Hangul}+</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseCommonCjkTwoCharacterLastNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseCommonCjkTwoCharacterLastNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kTwoCharacterCjkLastNamesRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:남궁|사공|서문|선우|제갈|황보|독고|망절|欧阳|令狐|皇甫|上官|司徒|诸葛|司马|宇文|呼延|端木|張簡|歐陽|諸葛|申屠|尉遲|司馬|軒轅|夏侯)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseCjkSingleCharacterLastNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseCjkSingleCharacterLastNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kCjkCharacterRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kCjkCharactersRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:\p{Han}|\p{Hangul}|\p{Katakana}|\p{Hiragana}|\p{Bopomofo})+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  </ol>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition Cascade
+  
+  (if <code>kHasHispanicLatinxNameCharacteristics</code>)
+  
+  </summary>
+  
+  Condition:<br>
+  
+
+
+
+<details>
+  <summary>Regex Reference: <code>kHasHispanicLatinxNameCharacteristics</code></summary>
+  
+
+
+  Regex concatenation
+  <ol>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">(?:</code>
+
+
+</li>
+    
+    <li>
+
+
+
+  Regex Reference: <code>kHispanicCommonLastNameCharacteristicsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:Aguilar|Alonso|Álvarez|Amador|Betancourt|Blanco|Burgos|Castillo|Castro|Chávez|Colón|Contreras|Cortez|Cruz|Delgado|Diaz|Díaz|Domínguez|Estrada|Fernandez|Fernández|Flores|Fuentes|Garcia|García|Garza|Gil|Gómez|González|Guerrero|Gutiérrez|Guzmán|Hernández|Herrera|Iglesias|Jiménez|Juárez|Lopez|López|Luna|Marín|Marroquín|Martín|Martinez|Martínez|Medina|Méndez|Mendoza|Molina|Morales|Moreno|Muñoz|Narvaez|Navarro|Núñez|Ortega|Ortiz|Ortíz|Peña|Perez|Pérez|Ramírez|Ramos|Reyes|Rivera|Rodriguez|Rodríguez|Rojas|Romero|Rosario|Rubio|Ruiz|Ruíz|Salazar|Sanchez|Sánchez|Santana|Santiago|Santos|Sanz|Serrano|Soto|Suárez|Toro|Torres|Vargas|Vasquez|Vásquez|Vázquez|Velásquez)</code>
+
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">|</code>
+
+
+</li>
+    
+    <li>
+
+
+
+  Regex Reference: <code>kHispanicLastNameConjunctionCharacteristicsRe</code> =&gt;
+  <code class="parsing-regexfragment">\s(?:y|e|i)\s</code>
+
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">)</code>
+
+
+</li>
+    
+  </ol>
+  Wrap as non-capture group: True
+
+
+
+</details>
+
+
+
+<br>
+  
+  Cascade:<br>
+  <ol>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseHispanicFullNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseHispanicFullNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>honorific-prefix</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHonorificPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:Master|Mr\.?|Miss\.?|Mrs\.?|Missus|Ms\.?|Mx\.?|M\.?|Ma&#39;am|Sir|Gentleman|Sire|Mistress|Madam|Ma&#39;am|Dame|Lord|Lady|Esq|Excellency|Excellence|Her Honour|His Honour|Hon\.?|The Right Honourable|The Most Honourable|Dr\.?|PhD|DPhil|MD|DO|Prof\.|Professor|QC|CL|Chancellor|Vice-Chancellor|Principle|Principal|President|Master|Warden|Dean|Regent|Rector|Provost|Director|Chief Executive|Imām|Shaykh|Muftī|Hāfiz|Hāfizah|Qārī|Mawlānā|Hājī|Sayyid|Sayyidah|Sharif|Eminent|Venerable|His Holiness|His Holiness|His All Holiness|His Beatitude|The Most Blessed|His Excellency|His Most Eminent Highness|His Eminence|Most Reverend Eminence|The Most Reverend|His Grace|His Lordship|The Reverend|Fr|Pr|Br|Sr|Elder|Rabbi|The Reverend|Cantor|Chief Rabbi|Grand Rabbi|Rebbetzin|Herr|Frau|Fräulein|Dame|PD|Doktor|Magister|Ingenieur|1lt|1st|2lt|2nd|3rd|admiral|capt|captain|col|cpt|dr|gen|general|lcdr|lt|ltc|ltg|ltjg|maj|major|mg|pastor|prof|rep|reverend|rev|sen|st)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_LAZY_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kMultipleLazyWordsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+(?:[^\S\r\n]+[^\s,]+)*?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>Capture Reference: <code>ParseHispanicLastNameExpression</code></summary>
+  
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kOptionalLastNamePrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:a|ab|af|av|ap|abu|aït|al|ālam|aust|austre|bar|bath|bat|ben|bin|ibn|bet|bint|binti|binte|da|das|de|degli|dele|del|du|della|der|di|dos|du|e|el|fetch|vetch|fitz|i??|kil|gil|de le|de la|la|le|lille|lu|m|mac|mc|mck|mhic|mic|mala|mellom|myljom|na|ned|nedre|neder|nic|ni|nin|nord|norr|ny|o|ua|ui|opp|upp|öfver|ost|öst|öster|øst|øst|østre|över|øvste|øvre|øver|öz|pour|putra|putri|setia|tor|söder|sør|sønder|sør|syd|søndre|syndre|søre|ter|ter|tre|van|van der|väst|väster|verch|erch|vest|vestre|vesle|vetle|von|zu|von und zu)\s)?</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHispanicLastNameConjunctionsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:y|e|i)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kOptionalLastNamePrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:a|ab|af|av|ap|abu|aït|al|ālam|aust|austre|bar|bath|bat|ben|bin|ibn|bet|bint|binti|binte|da|das|de|degli|dele|del|du|della|der|di|dos|du|e|el|fetch|vetch|fitz|i??|kil|gil|de le|de la|la|le|lille|lu|m|mac|mc|mck|mhic|mic|mala|mellom|myljom|na|ned|nedre|neder|nic|ni|nin|nord|norr|ny|o|ua|ui|opp|upp|öfver|ost|öst|öster|øst|øst|østre|över|øvste|øvre|øver|öz|pour|putra|putri|setia|tor|söder|sør|sønder|sør|syd|søndre|syndre|søre|ter|ter|tre|van|van der|väst|väster|verch|erch|vest|vestre|vesle|vetle|von|zu|von und zu)\s)?</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  </ol>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition Cascade
+  
+  </summary>
+  
+  Cascade:<br>
+  <ol>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseOnlyLastNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseOnlyLastNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kOptionalLastNamePrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:a|ab|af|av|ap|abu|aït|al|ālam|aust|austre|bar|bath|bat|ben|bin|ibn|bet|bint|binti|binte|da|das|de|degli|dele|del|du|della|der|di|dos|du|e|el|fetch|vetch|fitz|i??|kil|gil|de le|de la|la|le|lille|lu|m|mac|mc|mck|mhic|mic|mala|mellom|myljom|na|ned|nedre|neder|nic|ni|nin|nord|norr|ny|o|ua|ui|opp|upp|öfver|ost|öst|öster|øst|øst|østre|över|øvste|øvre|øver|öz|pour|putra|putri|setia|tor|söder|sør|sønder|sør|syd|søndre|syndre|søre|ter|ter|tre|van|van der|väst|väster|verch|erch|vest|vestre|vesle|vetle|von|zu|von und zu)\s)?</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kLastNameSuffixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:b\.a|ba|d\.d\.s|dds|ii|iii|iv|ix|jr|m\.a|m\.d|md|ms|ph\.?d|sr|v|vi|vii|viii|x)\.?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseLastCommaFirstMiddleNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseLastCommaFirstMiddleNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>honorific-prefix</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHonorificPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:Master|Mr\.?|Miss\.?|Mrs\.?|Missus|Ms\.?|Mx\.?|M\.?|Ma&#39;am|Sir|Gentleman|Sire|Mistress|Madam|Ma&#39;am|Dame|Lord|Lady|Esq|Excellency|Excellence|Her Honour|His Honour|Hon\.?|The Right Honourable|The Most Honourable|Dr\.?|PhD|DPhil|MD|DO|Prof\.|Professor|QC|CL|Chancellor|Vice-Chancellor|Principle|Principal|President|Master|Warden|Dean|Regent|Rector|Provost|Director|Chief Executive|Imām|Shaykh|Muftī|Hāfiz|Hāfizah|Qārī|Mawlānā|Hājī|Sayyid|Sayyidah|Sharif|Eminent|Venerable|His Holiness|His Holiness|His All Holiness|His Beatitude|The Most Blessed|His Excellency|His Most Eminent Highness|His Eminence|Most Reverend Eminence|The Most Reverend|His Grace|His Lordship|The Reverend|Fr|Pr|Br|Sr|Elder|Rabbi|The Reverend|Cantor|Chief Rabbi|Grand Rabbi|Rebbetzin|Herr|Frau|Fräulein|Dame|PD|Doktor|Magister|Ingenieur|1lt|1st|2lt|2nd|3rd|admiral|capt|captain|col|cpt|dr|gen|general|lcdr|lt|ltc|ltg|ltjg|maj|major|mg|pastor|prof|rep|reverend|rev|sen|st)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kOptionalLastNamePrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:a|ab|af|av|ap|abu|aït|al|ālam|aust|austre|bar|bath|bat|ben|bin|ibn|bet|bint|binti|binte|da|das|de|degli|dele|del|du|della|der|di|dos|du|e|el|fetch|vetch|fitz|i??|kil|gil|de le|de la|la|le|lille|lu|m|mac|mc|mck|mhic|mic|mala|mellom|myljom|na|ned|nedre|neder|nic|ni|nin|nord|norr|ny|o|ua|ui|opp|upp|öfver|ost|öst|öster|øst|øst|østre|över|øvste|øvre|øver|öz|pour|putra|putri|setia|tor|söder|sør|sønder|sør|syd|søndre|syndre|søre|ter|ter|tre|van|van der|väst|väster|verch|erch|vest|vestre|vesle|vetle|von|zu|von und zu)\s)?</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*,\s*</code>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>additional-name</code>
+    
+    (MATCH_LAZY_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kMultipleLazyWordsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+(?:[^\S\r\n]+[^\s,]+)*?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  <li>
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseFirstMiddleLastNameExpression</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseFirstMiddleLastNameExpression<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>honorific-prefix</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kHonorificPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:Master|Mr\.?|Miss\.?|Mrs\.?|Missus|Ms\.?|Mx\.?|M\.?|Ma&#39;am|Sir|Gentleman|Sire|Mistress|Madam|Ma&#39;am|Dame|Lord|Lady|Esq|Excellency|Excellence|Her Honour|His Honour|Hon\.?|The Right Honourable|The Most Honourable|Dr\.?|PhD|DPhil|MD|DO|Prof\.|Professor|QC|CL|Chancellor|Vice-Chancellor|Principle|Principal|President|Master|Warden|Dean|Regent|Rector|Provost|Director|Chief Executive|Imām|Shaykh|Muftī|Hāfiz|Hāfizah|Qārī|Mawlānā|Hājī|Sayyid|Sayyidah|Sharif|Eminent|Venerable|His Holiness|His Holiness|His All Holiness|His Beatitude|The Most Blessed|His Excellency|His Most Eminent Highness|His Eminence|Most Reverend Eminence|The Most Reverend|His Grace|His Lordship|The Reverend|Fr|Pr|Br|Sr|Elder|Rabbi|The Reverend|Cantor|Chief Rabbi|Grand Rabbi|Rebbetzin|Herr|Frau|Fräulein|Dame|PD|Doktor|Magister|Ingenieur|1lt|1st|2lt|2nd|3rd|admiral|capt|captain|col|cpt|dr|gen|general|lcdr|lt|ltc|ltg|ltjg|maj|major|mg|pastor|prof|rep|reverend|rev|sen|st)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>given-name</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>additional-name</code>
+    
+    (MATCH_LAZY_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kMultipleLazyWordsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+(?:[^\S\r\n]+[^\s,]+)*?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>family-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kOptionalLastNamePrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:a|ab|af|av|ap|abu|aït|al|ālam|aust|austre|bar|bath|bat|ben|bin|ibn|bet|bint|binti|binte|da|das|de|degli|dele|del|du|della|der|di|dos|du|e|el|fetch|vetch|fitz|i??|kil|gil|de le|de la|la|le|lille|lu|m|mac|mc|mck|mhic|mic|mala|mellom|myljom|na|ned|nedre|neder|nic|ni|nin|nord|norr|ny|o|ua|ui|opp|upp|öfver|ost|öst|öster|øst|øst|østre|över|øvste|øvre|øver|öz|pour|putra|putri|setia|tor|söder|sør|sønder|sør|syd|søndre|syndre|søre|ter|ter|tre|van|van der|väst|väster|verch|erch|vest|vestre|vesle|vetle|von|zu|von und zu)\s)?</code>
+
+
+
+</li>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kSingleWordRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      No capturing pattern
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kLastNameSuffixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:b\.a|ba|d\.d\.s|dds|ii|iii|iv|ix|jr|m\.a|m\.d|md|ms|ph\.?d|sr|v|vi|vii|viii|x)\.?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+</li>
+  
+  </ol>
+</details>
+
+
+</li>
+  
+  </ol>
+</details>
+
+
+
+
+</div>
+
 <div>
 <h4>Children:</h4>
 <ul>
@@ -1588,6 +3328,30 @@ Honorific prefix
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="given-name">
   <a href="#given-name">#</a>
   
@@ -1596,6 +3360,30 @@ Honorific prefix
 <div style="margin-left: 20px;">
 
 Given name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1610,6 +3398,30 @@ Additional given name (in Western cultures the middle name)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="family-name">
   <a href="#family-name">#</a>
   
@@ -1621,6 +3433,30 @@ Family name
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="address">
   <a href="#address">#</a>
   
@@ -1629,6 +3465,30 @@ Family name
 <div style="margin-left: 20px;">
 
 Address of a physical location - Artificial concept, not to be used in HTML
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1689,7 +3549,7 @@ Address of a physical location - Artificial concept, not to be used in HTML
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">address</span> =<br>
-<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
 </div>
 
 </div><h3 id="street-address">
@@ -1700,6 +3560,30 @@ Address of a physical location - Artificial concept, not to be used in HTML
 <div style="margin-left: 20px;">
 
 Street address (street and location within the street)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1759,6 +3643,30 @@ Street address (street and location within the street)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="address-line2">
   <a href="#address-line2">#</a>
   
@@ -1767,6 +3675,30 @@ Street address (street and location within the street)
 <div style="margin-left: 20px;">
 
 2nd line of street-address
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1781,6 +3713,30 @@ Street address (street and location within the street)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="address-line4">
   <a href="#address-line4">#</a>
   
@@ -1789,6 +3745,30 @@ Street address (street and location within the street)
 <div style="margin-left: 20px;">
 
 4th line of street-address
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1803,6 +3783,402 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h4>Parsing:</h4>
+<div class="parsing">
+
+
+
+
+<details>
+  <summary>Decomposition
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>street-address-alternative-1</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>Capture Reference: <code>ParseBuildingLocation</code></summary>
+  
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>building-location</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>street</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    Prefix:
+    
+
+
+
+  Regex Reference: <code>kStreetOptionalPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?</code>
+
+
+
+ <br>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kMultipleLazyWordsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+(?:[^\S\r\n]+[^\s,]+)*?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>building-and-unit</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>building</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+<details>
+  <summary>Regex Reference: <code>kBuildingValueRe</code></summary>
+  
+
+
+  Regex concatenation
+  <ol>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">\d+</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">(?:</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*[[:alpha:]]\b</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">)?</code>
+
+
+</li>
+    
+  </ol>
+  Wrap as non-capture group: False
+
+
+
+</details>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kHouseNumberAndUnitSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|[/\s]+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>Capture Reference: <code>ParseUnitWithOptionalPrefix</code></summary>
+  
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-type</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitTypeLiteralRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:mieszkanie|m\.?|lokal|lok\.?|apartment|apt\.?)?</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: 
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*</code>
+
+
+
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitNameValueRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:\d+\w?\b|\w\b)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+
+
+</div>
 
 <div>
 <h4>Children:</h4>
@@ -1831,7 +4207,7 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">street-address-alternative-1</span> =<br>
-<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span>
 </div>
 
 </div><h3 id="building-location">
@@ -1844,6 +4220,370 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 Name of a street and identifier for the building and the apartment
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h4>Parsing:</h4>
+<div class="parsing">
+
+
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseBuildingLocation</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseBuildingLocation<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>building-location</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>street</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    Prefix:
+    
+
+
+
+  Regex Reference: <code>kStreetOptionalPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?</code>
+
+
+
+ <br>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kMultipleLazyWordsRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:[^\s,]+(?:[^\S\r\n]+[^\s,]+)*?)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kWhitespaceSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|\s+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>building-and-unit</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>building</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+<details>
+  <summary>Regex Reference: <code>kBuildingValueRe</code></summary>
+  
+
+
+  Regex concatenation
+  <ol>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">\d+</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">(?:</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*[[:alpha:]]\b</code>
+
+
+</li>
+    
+    <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">)?</code>
+
+
+</li>
+    
+  </ol>
+  Wrap as non-capture group: False
+
+
+
+</details>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: Regex Reference <code>kHouseNumberAndUnitSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(?:^|[/\s]+)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>Capture Reference: <code>ParseUnitWithOptionalPrefix</code></summary>
+  
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-type</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitTypeLiteralRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:mieszkanie|m\.?|lokal|lok\.?|apartment|apt\.?)?</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: 
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*</code>
+
+
+
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitNameValueRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:\d+\w?\b|\w\b)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+
+
+</div>
 
 <div>
 <h4>Children:</h4>
@@ -1877,7 +4617,7 @@ Name of a street and identifier for the building and the apartment
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">building-location</span> =<br>
-<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span>
 </div>
 
 </div><h3 id="street">
@@ -1891,6 +4631,30 @@ Street name
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="building-and-unit">
   <a href="#building-and-unit">#</a>
   
@@ -1899,6 +4663,30 @@ Street name
 <div style="margin-left: 20px;">
 
 House number and apartment number
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1934,7 +4722,7 @@ House number and apartment number
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">building-and-unit</span> =<br>
-<span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit</span>
+<span class="formatting_token">building</span><span class="formatting_token_separator">/</span><span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span>
 </div>
 
 </div><h3 id="building">
@@ -1945,6 +4733,30 @@ House number and apartment number
 <div style="margin-left: 20px;">
 
 House number
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1959,6 +4771,268 @@ Unit in a building (e.g. &#34;Apartment 5&#34;, &#34;Suite 12&#34;)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h4>Parsing:</h4>
+<div class="parsing">
+
+
+
+
+<details>
+  <summary>Decomposition
+    
+    (<code>ParseUnitWithOptionalPrefix</code>)
+    
+  </summary>
+  Anchor beginning: True<br>
+  
+    Capture Reference: ParseUnitWithOptionalPrefix<br>
+    
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-type</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitTypeLiteralRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:mieszkanie|m\.?|lokal|lok\.?|apartment|apt\.?)?</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+        <li>
+
+
+
+Separator: 
+
+
+Regex Fragment: <code class="parsing-regexfragment">\s*</code>
+
+
+
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>unit-name</code>
+    
+    (MATCH_REQUIRED)
+  </summary>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+
+  Regex Reference: <code>kUnitNameValueRe</code> =&gt;
+  <code class="parsing-regexfragment">(?:\d+\w?\b|\w\b)</code>
+
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+
+  
+  Anchor end: True<br>
+</details>
+
+
+
+
+</div>
+
+<div>
+<h4>Children:</h4>
+<ul>
+
+  <li>
+    
+    <a href="#unit-type">unit-type</a>
+  </li>
+
+  <li>
+    
+    <a href="#unit-name">unit-name</a>
+  </li>
+
+</ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">unit</span> =
+<span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">unit</span> =<br>
+<span class="formatting_token">unit-type</span><span class="formatting_token">unit-name</span>
+</div>
+
+</div><h3 id="unit-type">
+  <a href="#unit-type">#</a>
+  
+  unit-type
+</h3>
+<div style="margin-left: 20px;">
+
+Type of a unit (e.g. &#34;Apt&#34;, &#34;Room&#34;, &#34;Store&#34;)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div><h3 id="unit-name">
+  <a href="#unit-name">#</a>
+  
+  unit-name
+</h3>
+<div style="margin-left: 20px;">
+
+Identifier of a unit (e.g. &#34;5&#34;)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="locality1">
   <a href="#locality1">#</a>
   
@@ -1967,6 +5041,30 @@ Unit in a building (e.g. &#34;Apartment 5&#34;, &#34;Suite 12&#34;)
 <div style="margin-left: 20px;">
 
 City
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1981,6 +5079,30 @@ State
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="postal-code">
   <a href="#postal-code">#</a>
   
@@ -1989,6 +5111,30 @@ State
 <div style="margin-left: 20px;">
 
 Postal code
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2003,6 +5149,30 @@ Postal code
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="country-name">
   <a href="#country-name">#</a>
   
@@ -2011,6 +5181,30 @@ Postal code
 <div style="margin-left: 20px;">
 
 Name of a country (e.g. &#34;Polska&#34;)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2025,6 +5219,30 @@ Name of an organization/company
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="credit-card">
   <a href="#credit-card">#</a>
   
@@ -2033,6 +5251,30 @@ Name of an organization/company
 <div style="margin-left: 20px;">
 
 Artificial concept, not to be used in HTML
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2081,6 +5323,30 @@ Artificial concept, not to be used in HTML
 <div style="margin-left: 20px;">
 
 Full name of credit card holder
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2135,6 +5401,30 @@ Given name of credit card holder
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-additional-name">
   <a href="#cc-additional-name">#</a>
   
@@ -2143,6 +5433,30 @@ Given name of credit card holder
 <div style="margin-left: 20px;">
 
 Additional name of credit card holder
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2157,6 +5471,30 @@ Family name of credit card holder
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-number">
   <a href="#cc-number">#</a>
   
@@ -2168,6 +5506,30 @@ Credit card number
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-exp-MMYY">
   <a href="#cc-exp-MMYY">#</a>
   
@@ -2176,6 +5538,30 @@ Credit card number
 <div style="margin-left: 20px;">
 
 Credit card expiration date in format MM/YY
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2225,6 +5611,30 @@ Credit card expiration month (2 digits)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-exp-YY">
   <a href="#cc-exp-YY">#</a>
   
@@ -2236,6 +5646,30 @@ Credit card expiration date in format YY (2 digits)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-exp-MMYYYY">
   <a href="#cc-exp-MMYYYY">#</a>
   
@@ -2244,6 +5678,30 @@ Credit card expiration date in format YY (2 digits)
 <div style="margin-left: 20px;">
 
 Credit card expiration date in format MM/YYYY
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2293,6 +5751,30 @@ Credit card expiration date in format YYYY (4 digits)
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="cc-csc">
   <a href="#cc-csc">#</a>
   
@@ -2301,6 +5783,30 @@ Credit card expiration date in format YYYY (4 digits)
 <div style="margin-left: 20px;">
 
 CSC/CVC/CVV number
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2315,6 +5821,30 @@ Credit card type
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="tel">
   <a href="#tel">#</a>
   
@@ -2323,6 +5853,30 @@ Credit card type
 <div style="margin-left: 20px;">
 
 Full telephone number
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2377,6 +5931,30 @@ Country code component of the telephone number
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="tel-national">
   <a href="#tel-national">#</a>
   
@@ -2385,6 +5963,30 @@ Country code component of the telephone number
 <div style="margin-left: 20px;">
 
 Telephone number without the county code component, with a country-internal prefix applied if applicable
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2436,6 +6038,30 @@ Area code component of the telephone number, with a country-internal prefix appl
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="tel-local">
   <a href="#tel-local">#</a>
   
@@ -2444,6 +6070,30 @@ Area code component of the telephone number, with a country-internal prefix appl
 <div style="margin-left: 20px;">
 
 Telephone number without the country code and area code components
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2495,6 +6145,30 @@ First part of the component of the telephone number that follows the area code, 
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="tel-local-suffix">
   <a href="#tel-local-suffix">#</a>
   
@@ -2503,6 +6177,30 @@ First part of the component of the telephone number that follows the area code, 
 <div style="margin-left: 20px;">
 
 Second part of the component of the telephone number that follows the area code, when that component is split into two components
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2518,6 +6216,30 @@ Telephone number internal extension code
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 </div><h3 id="email">
   <a href="#email">#</a>
   
@@ -2526,6 +6248,30 @@ Telephone number internal extension code
 <div style="margin-left: 20px;">
 
 Email address
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/model/countries/PL/PL-model.yaml
+++ b/model/countries/PL/PL-model.yaml
@@ -2,7 +2,6 @@ cut-off-children:
   - family-name
   - street
   - building
-  - unit
 
 cut-off-tokens:
   - honorific-suffix

--- a/model/countries/PL/PL-parsing-rules.yaml
+++ b/model/countries/PL/PL-parsing-rules.yaml
@@ -1,0 +1,196 @@
+regex_definitions:
+  kBuildingValueRe:  # Regex for type "building"
+    regex_concat:
+      parts:
+      - regex_fragment: \d+  # House number
+      # Optional suffix for building ids with a letter suffix, e.g. 12a.
+      - regex_fragment: '(?:'
+      # Single character suffix (e.g. "12 a" and "12a")
+      - regex_fragment: \s*[[:alpha:]]\b
+      - regex_fragment: ')?'
+      wrap_non_capture: false
+      
+  # Regular expression to match the prefixes that indicate a house number.
+  kStreetOptionalPrefixRe:
+    regex_fragment: '(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?'
+
+  # Regular expression to match the unit-types in Poland.
+  kUnitTypeLiteralRe:
+    regex_fragment: '(?:mieszkanie|m\.?|lokal|lok\.?|apartment|apt\.?)?'
+
+  kUnitNameValueRe:  # Regex for "unit-name"
+    regex_fragment: (?:\d+\w?\b|\w\b)
+
+  # Regular expression to match separator of house/building number and unit/apartment number.
+  kHouseNumberAndUnitSeparator:
+    regex_fragment: (?:^|[/\s]+)
+
+capture_definitions:
+  ParseBuildingLocation:
+    capture:
+      output: building-location
+      parts:
+      - capture:
+          output: street
+          prefix: {regex_reference: kStreetOptionalPrefixRe}
+          parts: [{regex_reference: kMultipleLazyWordsRe}]
+      - separator: {regex_reference: kWhitespaceSeparator}
+      - capture:
+          output: building-and-unit
+          parts:
+            - capture:
+                output: building
+                parts: [ {regex_reference: kBuildingValueRe} ]
+            - separator: {regex_reference: kHouseNumberAndUnitSeparator} 
+            - capture_reference: ParseUnitWithOptionalPrefix
+
+  ParseUnitWithOptionalPrefix:
+    capture:
+      output: unit
+      parts:
+      - capture:
+          output: unit-type
+          parts: [ {regex_reference: kUnitTypeLiteralRe} ]
+          quantifier: MATCH_OPTIONAL
+      - separator: {regex_fragment: '\s*' }
+      - capture:
+          output: unit-name
+          parts: [{regex_reference: kUnitNameValueRe}]
+      quantifier: MATCH_OPTIONAL
+
+
+parsing_definitions:
+  building-location:
+    decomposition: 
+      capture_reference: ParseBuildingLocation
+
+  street-address-alternative-1:
+    decomposition:
+      capture: 
+        output: street-address-alternative-1
+        parts:
+        - capture_reference: ParseBuildingLocation
+
+  unit:
+    decomposition:
+      capture_reference: ParseUnitWithOptionalPrefix
+
+
+test_parsing_definitions:
+- id: "Test 1"
+  type: building-location
+  input: "ul. Jan Warsaw 9/10"
+  output:
+    building-location: "ul. Jan Warsaw 9/10" 
+    street: "Jan Warsaw"
+    building-and-unit: "9/10"
+    building: "9"
+    unit: "10"
+    unit-name: "10"
+- id: "Test 2"
+  type: street-address-alternative-1
+  input: "ul. Jan Warsaw 9/10"
+  output:
+    street-address-alternative-1: "ul. Jan Warsaw 9/10"  
+    building-location: "ul. Jan Warsaw 9/10" 
+    street: "Jan Warsaw"
+    building-and-unit: "9/10"
+    building: "9"
+    unit: "10"
+    unit-name: "10" 
+- id: "Test 3"
+  type: street-address-alternative-1
+  input: "al. Warsaw 9/10"
+  output:
+    street-address-alternative-1: "al. Warsaw 9/10"  
+    building-location: "al. Warsaw 9/10" 
+    street: "Warsaw"
+    building-and-unit: "9/10"
+    building: "9"
+    unit: "10"
+    unit-name: "10"
+- id: "Test 4"
+  type: street-address-alternative-1
+  input: "Warsaw 9A/10"
+  output:
+    street-address-alternative-1: "Warsaw 9A/10"  
+    building-location: "Warsaw 9A/10" 
+    street: "Warsaw"
+    building-and-unit: "9A/10"
+    building: "9A"
+    unit: "10"
+    unit-name: "10"
+- id: "Test 5"
+  type: street-address-alternative-1
+  input: "Warsaw 9"
+  output:
+    street-address-alternative-1: "Warsaw 9"  
+    building-location: "Warsaw 9" 
+    street: "Warsaw"
+    building-and-unit: "9"
+    building: "9"
+- id: "Test 6"
+  type: street-address-alternative-1
+  input: "pl Warsaw 9"
+  output:
+    street-address-alternative-1: "pl Warsaw 9"  
+    building-location: "pl Warsaw 9" 
+    street: "Warsaw"
+    building-and-unit: "9"
+    building: "9"
+- id: "Test 7"
+  type: street-address-alternative-1
+  input: "pl Warsaw 9A"
+  output:
+    street-address-alternative-1: "pl Warsaw 9A"  
+    building-location: "pl Warsaw 9A" 
+    street: "Warsaw"
+    building-and-unit: "9A"
+    building: "9A"
+- id: "Test 8"
+  type: street-address-alternative-1
+  input: "aleja Warsaw 9A"
+  output:
+    street-address-alternative-1: "aleja Warsaw 9A"  
+    building-location: "aleja Warsaw 9A" 
+    street: "Warsaw"
+    building-and-unit: "9A"
+    building: "9A"
+- id: "Test 9"
+  type: street-address-alternative-1
+  input: "ul. Warsaw 9A m. 10"
+  output:
+    street-address-alternative-1: "ul. Warsaw 9A m. 10"  
+    building-location: "ul. Warsaw 9A m. 10" 
+    street: "Warsaw"
+    building-and-unit: "9A m. 10"
+    building: "9A"
+    unit: "m. 10"
+    unit-type: "m."
+    unit-name: "10"
+- id: "Test 10"
+  type: unit
+  input: "m. 10"
+  output:
+    unit: "m. 10"  
+    unit-type: "m."
+    unit-name: "10"
+- id: "Test 11"
+  type: unit
+  input: "m.10"
+  output:
+    unit: "m.10"  
+    unit-type: "m."
+    unit-name: "10"
+- id: "Test 12"
+  type: street-address-alternative-1
+  input: "ul. Warsaw 9A/m.10"
+  output:
+    street-address-alternative-1: "ul. Warsaw 9A/m.10"  
+    building-location: "ul. Warsaw 9A/m.10" 
+    street: "Warsaw"
+    building-and-unit: "9A/m.10"
+    building: "9A"
+    unit: "m.10"
+    unit-type: "m."
+    unit-name: "10"


### PR DESCRIPTION
Add parsing rules for Poland data model.

Currently, covering the parsing which includes building number separation with apartment number by slash (only this case).
PTAL examples in parsing-rules file.
Source used to identify optional prefixes for street: BARD and https://www.grcdi.nl/gsb/poland.html