### PR TITLE
Add ADDRESS_HOME_DEPENDENT_LOCALITY for France model

### DIFF
--- a/docs/model/FR.html
+++ b/docs/model/FR.html
@@ -641,6 +641,22 @@
   <div class="concept-id">
     
     
+    <a href="#locality2">locality2</a>
+    - 2nd biggest type of a locality, e.g. a suburb
+      
+        
+      
+    
+  </div>
+  
+</div>
+
+        
+          
+<div class="concept">
+  <div class="concept-id">
+    
+    
     <a href="#admin-area1">admin-area1</a>
     - Biggest type of admin area if a country has multiple levels
       
@@ -1270,6 +1286,8 @@
       
         
       
+        
+      
     </table>
   </td>
   <td valign="top">
@@ -1355,6 +1373,12 @@
       
         
         <tr>
+          <td>locality2</td><td><pre style="margin:0">Quartier du Marais</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
           <td>admin-area1</td><td><pre style="margin:0">Nord-Pas-de-Calais</pre></td>
         </tr>
         
@@ -1430,6 +1454,7 @@
       Output for "address":<br>
       <pre class="formatting_example_textbox">Appartament 36
 1661 Place Charles de Gaulle
+Quartier du Marais
 59491 Villeneuve-d&#39;ascq
 France</pre>
       
@@ -3396,6 +3421,11 @@ Address of a physical location - Artificial concept, not to be used in HTML
 
   <li>
     
+    <a href="#locality2">locality2</a>
+  </li>
+
+  <li>
+    
     <a href="#admin-area1">admin-area1</a>
   </li>
 
@@ -3426,13 +3456,13 @@ Address of a physical location - Artificial concept, not to be used in HTML
 <h4>Formatting:</h4>
 <div>
 <span class="formatting_token">address</span> =
-<span class="formatting_token">street-address-alternative-1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">country-name</span>
+<span class="formatting_token">street-address-alternative-1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">locality2</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">country-name</span>
 </div>
 
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">address</span> =<br>
-<span class="formatting_token">address-overflow</span><span class="formatting_token_separator"><br></span><span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
+<span class="formatting_token">address-overflow</span><span class="formatting_token_separator"><br></span><span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span><span class="formatting_token_separator"><br></span><span class="formatting_token">locality2</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
 </div>
 
 </div><h3 id="street-address">
@@ -4388,6 +4418,41 @@ An overflow field for information that is not captured differently in a form
 <div style="margin-left: 20px;">
 
 Biggest sub type of a locality, often a city
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div><h3 id="locality2">
+  <a href="#locality2">#</a>
+  
+  locality2
+</h3>
+<div style="margin-left: 20px;">
+
+2nd biggest type of a locality, e.g. a suburb
 
 
 

--- a/model/countries/FR/FR-desriptions.yaml
+++ b/model/countries/FR/FR-desriptions.yaml
@@ -1,0 +1,2 @@
+short-descriptions:
+  locality2: Specific neighborhood within the city.

--- a/model/countries/FR/FR-formatting-rules.yaml
+++ b/model/countries/FR/FR-formatting-rules.yaml
@@ -2,6 +2,8 @@ formatting-rules:
   address:
   - street-address-alternative-1
   - separator: "\n"
+  - locality2
+  - separator: "\n"
   - postal-code
   - separator: " "
   - locality1
@@ -41,6 +43,7 @@ examples:
     building: 1661
     address-overflow: Appartament 36
     locality1: Villeneuve-d'ascq
+    locality2: Quartier du Marais
     postal-code: 59491
     admin-area1: Nord-Pas-de-Calais
     country: FR
@@ -52,5 +55,6 @@ examples:
       text: |
         Appartament 36
         1661 Place Charles de Gaulle
+        Quartier du Marais
         59491 Villeneuve-d'ascq
         France

--- a/model/countries/FR/FR-model.yaml
+++ b/model/countries/FR/FR-model.yaml
@@ -9,7 +9,6 @@ cut-off-tokens:
   - admin-area2
   - admin-area3
   - admin-area4
-  - locality2
   - locality3
   - locality4
 


### PR DESCRIPTION
This CL add-s ADDRESS_HOME_DEPENDENT_LOCALITY/locality2 (neighbourhood) to FR model and adjusts formatting.
According to examples: https://www.smarty.com/articles/la-poste#example
Indicating the small area/neighbourhood - facultatif/lieu-dit is mostly optional and is indicated after street address and before postal code and city.
Also, according to [colab](https://colab.corp.google.com/drive/1DgTs61VkugUStLLxz-JHDj3jYyeySdCq?resourcekey=0-TfkiPhRNHf5o05sSZzNMPA#scrollTo=4L-eiaL-Vs9K), based on filtering address-related fields and specifically ADDRESS_DEPENDANT_LOCALITY identified by raters, it is around 2% in comparison to all the address-related fields and 10% in comparison to ADDRESS_HOME_CITY fields.