### PR TITLE
Fix PL street prefixes formatting rules

### DIFF
--- a/docs/model/PL.html
+++ b/docs/model/PL.html
@@ -4057,7 +4057,7 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 
 
   Regex Reference: <code>kStreetOptionalPrefixRe</code> =&gt;
-  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?</code>
+  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?)\s*)?</code>
 
 
 
@@ -4476,7 +4476,7 @@ Name of a street and identifier for the building and the apartment
 
 
   Regex Reference: <code>kStreetOptionalPrefixRe</code> =&gt;
-  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?</code>
+  <code class="parsing-regexfragment">(?:(?:ulica|ul\.?)\s*)?</code>
 
 
 

--- a/model/countries/PL/PL-parsing-rules.yaml
+++ b/model/countries/PL/PL-parsing-rules.yaml
@@ -12,7 +12,7 @@ regex_definitions:
       
   # Regular expression to match the prefixes that indicate a house number.
   kStreetOptionalPrefixRe:
-    regex_fragment: '(?:(?:ulica|ul\.?|aleja|al\.?|plac|pl\.?|skwer|rondo|osiedle|boczna|bulwar|droga|rynek|szosa|zaulek)\s*)?'
+    regex_fragment: '(?:(?:ulica|ul\.?)\s*)?'
 
   # Regular expression to match the unit-types in Poland.
   kUnitTypeLiteralRe:
@@ -115,7 +115,7 @@ test_parsing_definitions:
   output:
     street-address-alternative-1: "al. Warsaw 9/10"  
     building-location: "al. Warsaw 9/10" 
-    street: "Warsaw"
+    street: "al. Warsaw"
     building-and-unit: "9/10"
     building: "9"
     unit: "10"
@@ -146,7 +146,7 @@ test_parsing_definitions:
   output:
     street-address-alternative-1: "pl Warsaw 9"  
     building-location: "pl Warsaw 9" 
-    street: "Warsaw"
+    street: "pl Warsaw"
     building-and-unit: "9"
     building: "9"
 - id: "Test 7"
@@ -155,7 +155,7 @@ test_parsing_definitions:
   output:
     street-address-alternative-1: "pl Warsaw 9A"  
     building-location: "pl Warsaw 9A" 
-    street: "Warsaw"
+    street: "pl Warsaw"
     building-and-unit: "9A"
     building: "9A"
 - id: "Test 8"
@@ -164,7 +164,7 @@ test_parsing_definitions:
   output:
     street-address-alternative-1: "aleja Warsaw 9A"  
     building-location: "aleja Warsaw 9A" 
-    street: "Warsaw"
+    street: "aleja Warsaw"
     building-and-unit: "9A"
     building: "9A"
 - id: "Test 9"


### PR DESCRIPTION
This commit addresses inconsistencies in handling Polish street prefixes during address parsing.
- The common prefix "ul./ulica" can be omitted, as it is often implied when referring to a street name (e.g., "Wilanowska" is understood as "ulica Wilanowska").
- Prefixes like "al./aleja", "rondo", etc. are now preserved as they are essential parts of the address and convey important location information (e.g., Google Warsaw Office address is "rondo Daszyńskiego 2C". Proper street name would be "rondo Daszyńskiego" instead of "Daszyńskiego". Same for "al. Wilanowska" which shouldn't be understand as "Wilanowska", since "ul. Wilanowska" is a different street in Warsaw).
