### PR TITLE
Fix FR formatting

### DIFF
--- a/docs/model/FR.html
+++ b/docs/model/FR.html
@@ -3944,7 +3944,7 @@ Separator: Regex Reference <code>kCommaOrWhitespaceSeparator</code> =&gt;
 
 
 Separator: Regex Reference <code>kCommaOrNewlineSeparator</code> =&gt;
-  <code class="parsing-regexfragment">(,|, |\n)</code>
+  <code class="parsing-regexfragment">(?:, |\n|\r|,)+</code>
 
 
 

--- a/docs/model/FR.html
+++ b/docs/model/FR.html
@@ -3965,10 +3965,7 @@ Separator: Regex Reference <code>kCommaOrNewlineSeparator</code> =&gt;
     
 
 
-
-  Regex Reference: <code>kSpaceOptionalPrefixRe</code> =&gt;
-  <code class="parsing-regexfragment">[ ]*</code>
-
+Regex Fragment: <code class="parsing-regexfragment">\s*</code>
 
 
  <br>

--- a/docs/model/FR.html
+++ b/docs/model/FR.html
@@ -1452,8 +1452,8 @@
   <td valign="top">
     
       Output for "address":<br>
-      <pre class="formatting_example_textbox">Appartament 36
-1661 Place Charles de Gaulle
+      <pre class="formatting_example_textbox">1661 Place Charles de Gaulle
+Appartament 36
 Quartier du Marais
 59491 Villeneuve-d&#39;ascq
 France</pre>
@@ -3462,7 +3462,7 @@ Address of a physical location - Artificial concept, not to be used in HTML
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">address</span> =<br>
-<span class="formatting_token">address-overflow</span><span class="formatting_token_separator"><br></span><span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span><span class="formatting_token_separator"><br></span><span class="formatting_token">locality2</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
+<span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-overflow</span><span class="formatting_token_separator"><br></span><span class="formatting_token">locality2</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
 </div>
 
 </div><h3 id="street-address">
@@ -3755,49 +3755,6 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 
 
 <details>
-  <summary>
-    
-      Capture <code>address-overflow</code>
-    
-    (MATCH_OPTIONAL)
-  </summary>
-    
-    
-      Parts: <br>
-      <ul>
-        
-        <li>
-
-
-Regex Fragment: <code class="parsing-regexfragment">(?:[^,\r\n]+)</code>
-
-
-</li>
-        
-      </ul>
-    
-    
-    
-</details>
-
-
-</li>
-        
-        <li>
-
-
-
-Separator: Regex Reference <code>kCommaOrWhitespaceSeparator</code> =&gt;
-  <code class="parsing-regexfragment">(?:^|[,\s]+)</code>
-
-
-
-</li>
-        
-        <li>
-
-
-<details>
   <summary>Capture Reference: <code>ParseBuildingLocation</code></summary>
   
     
@@ -3982,6 +3939,61 @@ Separator: Regex Reference <code>kCommaOrWhitespaceSeparator</code> =&gt;
 
 </li>
         
+        <li>
+
+
+
+Separator: Regex Reference <code>kCommaOrNewlineSeparator</code> =&gt;
+  <code class="parsing-regexfragment">(,|, |\n)</code>
+
+
+
+</li>
+        
+        <li>
+
+
+<details>
+  <summary>
+    
+      Capture <code>address-overflow</code>
+    
+    (MATCH_OPTIONAL)
+  </summary>
+    
+    Prefix:
+    
+
+
+
+  Regex Reference: <code>kSpaceOptionalPrefixRe</code> =&gt;
+  <code class="parsing-regexfragment">[ ]*</code>
+
+
+
+ <br>
+    
+    
+      Parts: <br>
+      <ul>
+        
+        <li>
+
+
+Regex Fragment: <code class="parsing-regexfragment">(?:[^\r\n]+)</code>
+
+
+</li>
+        
+      </ul>
+    
+    
+    
+</details>
+
+
+</li>
+        
       </ul>
     
     
@@ -4025,13 +4037,13 @@ Separator: Regex Reference <code>kCommaOrWhitespaceSeparator</code> =&gt;
 <h4>Formatting:</h4>
 <div>
 <span class="formatting_token">street-address-alternative-1</span> =
-<span class="formatting_token">address-overflow</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">building-location</span>
+<span class="formatting_token">building-location</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-overflow</span>
 </div>
 
 <h5>Flattened formatting:</h5>
 <div>
 <span class="formatting_token">street-address-alternative-1</span> =<br>
-<span class="formatting_token">address-overflow</span><span class="formatting_token_separator"><br></span><span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span>
+<span class="formatting_token">building</span><span class="formatting_token_separator">␣</span><span class="formatting_token">street</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-overflow</span>
 </div>
 
 </div><h3 id="building-location">

--- a/model/countries/FR/FR-formatting-rules.yaml
+++ b/model/countries/FR/FR-formatting-rules.yaml
@@ -14,9 +14,9 @@ formatting-rules:
   - skip: admin-area1  # redundant with postal-code
 
   street-address-alternative-1:
-  - address-overflow
-  - separator: "\n"
   - building-location
+  - separator: "\n"
+  - address-overflow
 
   building-location:
   - building
@@ -53,8 +53,8 @@ examples:
     address:
       show: true
       text: |
-        Appartament 36
         1661 Place Charles de Gaulle
+        Appartament 36
         Quartier du Marais
         59491 Villeneuve-d'ascq
         France

--- a/model/countries/FR/FR-parsing-rules.yaml
+++ b/model/countries/FR/FR-parsing-rules.yaml
@@ -20,9 +20,6 @@ regex_definitions:
   kCommaOrNewlineSeparator:
     regex_fragment: '(,|, |\n)'
 
-  kSpaceOptionalPrefixRe:
-    regex_fragment: '[ ]*'
-
 capture_definitions:
   ParseBuildingLocation:
     capture:
@@ -46,7 +43,7 @@ capture_definitions:
       - separator: {regex_reference: kCommaOrNewlineSeparator}
       - capture:
           output: address-overflow
-          prefix: {regex_reference: kSpaceOptionalPrefixRe}
+          prefix: {regex_fragment: '\s*'}
           parts: [ {regex_fragment: '(?:[^\r\n]+)'} ]
           quantifier: MATCH_OPTIONAL
 

--- a/model/countries/FR/FR-parsing-rules.yaml
+++ b/model/countries/FR/FR-parsing-rules.yaml
@@ -116,9 +116,9 @@ test_parsing_definitions:
     address-overflow: "Appartement 36"
 - id: "Test 8"
   type: street-address-alternative-1
-  input: "58 rue du Gue Jacquet,Appartement 1"
+  input: "58 rue du Gue Jacquet, Appartement 1"
   output:
-    street-address-alternative-1: "58 rue du Gue Jacquet,Appartement 1"
+    street-address-alternative-1: "58 rue du Gue Jacquet, Appartement 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"
@@ -134,9 +134,9 @@ test_parsing_definitions:
     address-overflow: "App 1"
 - id: "Test 10"
   type: street-address-alternative-1
-  input: "58 rue du Gue Jacquet,Appt 1"
+  input: "58 rue du Gue Jacquet, Appt 1"
   output:
-    street-address-alternative-1: "58 rue du Gue Jacquet,Appt 1"
+    street-address-alternative-1: "58 rue du Gue Jacquet, Appt 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"
@@ -150,3 +150,12 @@ test_parsing_definitions:
     street: "rue du Gue Jacquet"
     building: "58"
     address-overflow: "Apt. 1"
+- id: "Test 12"
+  type: street-address-alternative-1
+  input: "1661 Place Charles de Gaulle, Floor 5, Apartment 2"
+  output:
+    street-address-alternative-1: "1661 Place Charles de Gaulle, Floor 5, Apartment 2"
+    building-location: "1661 Place Charles de Gaulle"
+    street: "Place Charles de Gaulle"
+    building: "1661"
+    address-overflow: "Floor 5, Apartment 2"

--- a/model/countries/FR/FR-parsing-rules.yaml
+++ b/model/countries/FR/FR-parsing-rules.yaml
@@ -59,52 +59,52 @@ parsing_definitions:
       capture_reference: StreetAddressDecomposition
 
 test_parsing_definitions:
-# - id: "Test 1"
-#   type: building-location
-#   input: "1661 Place Charles de Gaulle"
-#   output:
-#     street: "Place Charles de Gaulle"
-#     building: "1661"
-# - id: "Test 2"
-#   type: building-location
-#   input: "58 rue du Gue Jacquet"
-#   output:
-#     street: "rue du Gue Jacquet"
-#     building: "58"
-# - id: "Test 3"
-#   type: street-address-alternative-1
-#   input: "58 rue du Gue Jacquet"
-#   output:
-#     street-address-alternative-1: "58 rue du Gue Jacquet"
-#     building-location: "58 rue du Gue Jacquet"
-#     street: "rue du Gue Jacquet"
-#     building: "58"
-# - id: "Test 4"
-#   type: street-address-alternative-1
-#   input: "1661 Place Charles de Gaulle"
-#   output:
-#     street-address-alternative-1: "1661 Place Charles de Gaulle"
-#     building-location: "1661 Place Charles de Gaulle"
-#     street: "Place Charles de Gaulle"
-#     building: "1661"
-# - id: "Test 5"
-#   type: street-address-alternative-1
-#   input: "1661 Place Charles de Gaulle\n Appartement 36"
-#   output:
-#     street-address-alternative-1: "1661 Place Charles de Gaulle\n Appartement 36"
-#     building-location: "1661 Place Charles de Gaulle"
-#     street: "Place Charles de Gaulle"
-#     building: "1661"
-#     address-overflow: "Appartement 36"
-# - id: "Test 6"
-#   type: street-address-alternative-1
-#   input: "58 rue du Gue Jacquet\nAppartement 1"
-#   output:
-#     street-address-alternative-1: "58 rue du Gue Jacquet\nAppartement 1"
-#     building-location: "58 rue du Gue Jacquet"
-#     street: "rue du Gue Jacquet"
-#     building: "58"
-#     address-overflow: "Appartement 1"
+- id: "Test 1"
+  type: building-location
+  input: "1661 Place Charles de Gaulle"
+  output:
+    street: "Place Charles de Gaulle"
+    building: "1661"
+- id: "Test 2"
+  type: building-location
+  input: "58 rue du Gue Jacquet"
+  output:
+    street: "rue du Gue Jacquet"
+    building: "58"
+- id: "Test 3"
+  type: street-address-alternative-1
+  input: "58 rue du Gue Jacquet"
+  output:
+    street-address-alternative-1: "58 rue du Gue Jacquet"
+    building-location: "58 rue du Gue Jacquet"
+    street: "rue du Gue Jacquet"
+    building: "58"
+- id: "Test 4"
+  type: street-address-alternative-1
+  input: "1661 Place Charles de Gaulle"
+  output:
+    street-address-alternative-1: "1661 Place Charles de Gaulle"
+    building-location: "1661 Place Charles de Gaulle"
+    street: "Place Charles de Gaulle"
+    building: "1661"
+- id: "Test 5"
+  type: street-address-alternative-1
+  input: "1661 Place Charles de Gaulle\n Appartement 36"
+  output:
+    street-address-alternative-1: "1661 Place Charles de Gaulle\n Appartement 36"
+    building-location: "1661 Place Charles de Gaulle"
+    street: "Place Charles de Gaulle"
+    building: "1661"
+    address-overflow: "Appartement 36"
+- id: "Test 6"
+  type: street-address-alternative-1
+  input: "58 rue du Gue Jacquet\nAppartement 1"
+  output:
+    street-address-alternative-1: "58 rue du Gue Jacquet\nAppartement 1"
+    building-location: "58 rue du Gue Jacquet"
+    street: "rue du Gue Jacquet"
+    building: "58"
+    address-overflow: "Appartement 1"
 - id: "Test 7"
   type: street-address-alternative-1
   input: "1661 Place Charles de Gaulle, Appartement 36"

--- a/model/countries/FR/FR-parsing-rules.yaml
+++ b/model/countries/FR/FR-parsing-rules.yaml
@@ -18,7 +18,7 @@ regex_definitions:
     regex_fragment: '(?:(?:no|nr|°|º|numéro)[-.\s]*)?'
   
   kCommaOrNewlineSeparator:
-    regex_fragment: '(,|, |\n)'
+    regex_fragment: '(?:, |\n|\r|,)+'
 
 capture_definitions:
   ParseBuildingLocation:
@@ -131,9 +131,9 @@ test_parsing_definitions:
     address-overflow: "App 1"
 - id: "Test 10"
   type: street-address-alternative-1
-  input: "58 rue du Gue Jacquet, Appt 1"
+  input: "58 rue du Gue Jacquet,Appt 1"
   output:
-    street-address-alternative-1: "58 rue du Gue Jacquet, Appt 1"
+    street-address-alternative-1: "58 rue du Gue Jacquet,Appt 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"

--- a/model/countries/FR/FR-parsing-rules.yaml
+++ b/model/countries/FR/FR-parsing-rules.yaml
@@ -16,6 +16,12 @@ regex_definitions:
   # Regular expression to match the prefixes that indicate a house number or name.
   kHouseNumberOrNameOptionalPrefixRe:
     regex_fragment: '(?:(?:no|nr|°|º|numéro)[-.\s]*)?'
+  
+  kCommaOrNewlineSeparator:
+    regex_fragment: '(,|, |\n)'
+
+  kSpaceOptionalPrefixRe:
+    regex_fragment: '[ ]*'
 
 capture_definitions:
   ParseBuildingLocation:
@@ -36,14 +42,13 @@ capture_definitions:
     capture:
       output: street-address-alternative-1
       parts:
+      - capture_reference: ParseBuildingLocation
+      - separator: {regex_reference: kCommaOrNewlineSeparator}
       - capture:
           output: address-overflow
-          parts: [ {regex_fragment: '(?:[^,\r\n]+)'} ]
+          prefix: {regex_reference: kSpaceOptionalPrefixRe}
+          parts: [ {regex_fragment: '(?:[^\r\n]+)'} ]
           quantifier: MATCH_OPTIONAL
-      - separator: {regex_reference: kCommaOrWhitespaceSeparator}
-      - capture_reference: ParseBuildingLocation
-
-
 
 parsing_definitions:
   building-location:
@@ -54,93 +59,93 @@ parsing_definitions:
       capture_reference: StreetAddressDecomposition
 
 test_parsing_definitions:
-- id: "Test 1"
-  type: building-location
-  input: "1661 Place Charles de Gaulle"
-  output:
-    street: "Place Charles de Gaulle"
-    building: "1661"
-- id: "Test 2"
-  type: building-location
-  input: "58 rue du Gue Jacquet"
-  output:
-    street: "rue du Gue Jacquet"
-    building: "58"
-- id: "Test 3"
-  type: street-address-alternative-1
-  input: "58 rue du Gue Jacquet"
-  output:
-    street-address-alternative-1: "58 rue du Gue Jacquet"
-    building-location: "58 rue du Gue Jacquet"
-    street: "rue du Gue Jacquet"
-    building: "58"
-- id: "Test 4"
-  type: street-address-alternative-1
-  input: "1661 Place Charles de Gaulle"
-  output:
-    street-address-alternative-1: "1661 Place Charles de Gaulle"
-    building-location: "1661 Place Charles de Gaulle"
-    street: "Place Charles de Gaulle"
-    building: "1661"
-- id: "Test 5"
-  type: street-address-alternative-1
-  input: "Appartement 36\n1661 Place Charles de Gaulle"
-  output:
-    street-address-alternative-1: "Appartement 36\n1661 Place Charles de Gaulle"
-    building-location: "1661 Place Charles de Gaulle"
-    street: "Place Charles de Gaulle"
-    building: "1661"
-    address-overflow: "Appartement 36"
-- id: "Test 6"
-  type: street-address-alternative-1
-  input: "Appartement 1\n58 rue du Gue Jacquet"
-  output:
-    street-address-alternative-1: "Appartement 1\n58 rue du Gue Jacquet"
-    building-location: "58 rue du Gue Jacquet"
-    street: "rue du Gue Jacquet"
-    building: "58"
-    address-overflow: "Appartement 1"
+# - id: "Test 1"
+#   type: building-location
+#   input: "1661 Place Charles de Gaulle"
+#   output:
+#     street: "Place Charles de Gaulle"
+#     building: "1661"
+# - id: "Test 2"
+#   type: building-location
+#   input: "58 rue du Gue Jacquet"
+#   output:
+#     street: "rue du Gue Jacquet"
+#     building: "58"
+# - id: "Test 3"
+#   type: street-address-alternative-1
+#   input: "58 rue du Gue Jacquet"
+#   output:
+#     street-address-alternative-1: "58 rue du Gue Jacquet"
+#     building-location: "58 rue du Gue Jacquet"
+#     street: "rue du Gue Jacquet"
+#     building: "58"
+# - id: "Test 4"
+#   type: street-address-alternative-1
+#   input: "1661 Place Charles de Gaulle"
+#   output:
+#     street-address-alternative-1: "1661 Place Charles de Gaulle"
+#     building-location: "1661 Place Charles de Gaulle"
+#     street: "Place Charles de Gaulle"
+#     building: "1661"
+# - id: "Test 5"
+#   type: street-address-alternative-1
+#   input: "1661 Place Charles de Gaulle\n Appartement 36"
+#   output:
+#     street-address-alternative-1: "1661 Place Charles de Gaulle\n Appartement 36"
+#     building-location: "1661 Place Charles de Gaulle"
+#     street: "Place Charles de Gaulle"
+#     building: "1661"
+#     address-overflow: "Appartement 36"
+# - id: "Test 6"
+#   type: street-address-alternative-1
+#   input: "58 rue du Gue Jacquet\nAppartement 1"
+#   output:
+#     street-address-alternative-1: "58 rue du Gue Jacquet\nAppartement 1"
+#     building-location: "58 rue du Gue Jacquet"
+#     street: "rue du Gue Jacquet"
+#     building: "58"
+#     address-overflow: "Appartement 1"
 - id: "Test 7"
   type: street-address-alternative-1
-  input: "Appartement 36, 1661 Place Charles de Gaulle"
+  input: "1661 Place Charles de Gaulle, Appartement 36"
   output:
-    street-address-alternative-1: "Appartement 36, 1661 Place Charles de Gaulle"
+    street-address-alternative-1: "1661 Place Charles de Gaulle, Appartement 36"
     building-location: "1661 Place Charles de Gaulle"
     street: "Place Charles de Gaulle"
     building: "1661"
     address-overflow: "Appartement 36"
 - id: "Test 8"
   type: street-address-alternative-1
-  input: "Appartement 1, 58 rue du Gue Jacquet"
+  input: "58 rue du Gue Jacquet,Appartement 1"
   output:
-    street-address-alternative-1: "Appartement 1, 58 rue du Gue Jacquet"
+    street-address-alternative-1: "58 rue du Gue Jacquet,Appartement 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"
     address-overflow: "Appartement 1"
 - id: "Test 9"
   type: street-address-alternative-1
-  input: "App 1, 58 rue du Gue Jacquet"
+  input: "58 rue du Gue Jacquet, App 1"
   output:
-    street-address-alternative-1: "App 1, 58 rue du Gue Jacquet"
+    street-address-alternative-1: "58 rue du Gue Jacquet, App 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"
     address-overflow: "App 1"
 - id: "Test 10"
   type: street-address-alternative-1
-  input: "Appt 1, 58 rue du Gue Jacquet"
+  input: "58 rue du Gue Jacquet,Appt 1"
   output:
-    street-address-alternative-1: "Appt 1, 58 rue du Gue Jacquet"
+    street-address-alternative-1: "58 rue du Gue Jacquet,Appt 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"
     address-overflow: "Appt 1"
 - id: "Test 11"
   type: street-address-alternative-1
-  input: "Apt. 1, 58 rue du Gue Jacquet"
+  input: "58 rue du Gue Jacquet, Apt. 1"
   output:
-    street-address-alternative-1: "Apt. 1, 58 rue du Gue Jacquet"
+    street-address-alternative-1: "58 rue du Gue Jacquet, Apt. 1"
     building-location: "58 rue du Gue Jacquet"
     street: "rue du Gue Jacquet"
     building: "58"


### PR DESCRIPTION
This CL changes the formatting expression for address_overflow, making it go second after the building location