### PR TITLE
Add NL formatting rules

### DIFF
--- a/docs/model/NL.html
+++ b/docs/model/NL.html
@@ -1320,6 +1320,480 @@ information about the floor or part of the building. </p>
     <div>&nbsp;</div>
     
   </div>
+</div>
+
+<div class="mdl-card mdl-shadow--2dp" style="width: 95%; margin: 8px">
+  <div class="mdl-card__title">
+    <h2 class="mdl-card__title-text">Example addresses</h2>
+  </div>
+  <div class="mdl-card__actions mdl-card--border">
+    <table class="formatting_example_overview_table">
+      
+      
+<tr>
+  <td colspan="2">
+    <b>name</b>: This is an example of a name.
+
+  </td>
+</tr>
+<tr>
+  <th>Input</th>
+  <th>Output</th>
+</tr>
+<tr>
+  <td valign="top">
+    <table>
+      
+        
+      
+        
+      
+        
+        <tr>
+          <td>given-name</td><td><pre style="margin:0">Vincent</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>additional-name</td><td><pre style="margin:0">Willem</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>family-name</td><td><pre style="margin:0">van Gogh</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    </table>
+  </td>
+  <td valign="top">
+    
+      Output for "name":<br>
+      <pre class="formatting_example_textbox">Vincent Willem van Gogh</pre>
+      
+      
+    
+  </td>
+</tr>
+<tr>
+  <td span="2">
+    &nbsp;
+  </td>
+</tr>
+
+      
+      
+<tr>
+  <td colspan="2">
+    <b>address</b>: This is an example of a full address in the Netherlands.
+
+  </td>
+</tr>
+<tr>
+  <th>Input</th>
+  <th>Output</th>
+</tr>
+<tr>
+  <td valign="top">
+    <table>
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+        <tr>
+          <td>street</td><td><pre style="margin:0">Kerkstraat</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building-and-unit</td><td><pre style="margin:0">10A</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building</td><td><pre style="margin:0">10</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>unit</td><td><pre style="margin:0">A</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>locality1</td><td><pre style="margin:0">Amsterdam</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+        <tr>
+          <td>postal-code</td><td><pre style="margin:0">1234 AB</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country</td><td><pre style="margin:0">NL</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country-name</td><td><pre style="margin:0">Netherlands</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    </table>
+  </td>
+  <td valign="top">
+    
+      Output for "address":<br>
+      <pre class="formatting_example_textbox">Kerkstraat 10A
+1234 AB Amsterdam
+Netherlands</pre>
+      
+      
+    
+  </td>
+</tr>
+<tr>
+  <td span="2">
+    &nbsp;
+  </td>
+</tr>
+
+      
+      
+<tr>
+  <td colspan="2">
+    <b>address-without-unit</b>: This is an example of an address without indication of unit in the Netherlands.
+
+  </td>
+</tr>
+<tr>
+  <th>Input</th>
+  <th>Output</th>
+</tr>
+<tr>
+  <td valign="top">
+    <table>
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+        <tr>
+          <td>street</td><td><pre style="margin:0">Kerkstraat</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building-and-unit</td><td><pre style="margin:0">10</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>building</td><td><pre style="margin:0">10</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+        <tr>
+          <td>locality1</td><td><pre style="margin:0">Amsterdam</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+        <tr>
+          <td>postal-code</td><td><pre style="margin:0">1234 AB</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country</td><td><pre style="margin:0">NL</pre></td>
+        </tr>
+        
+      
+        
+        <tr>
+          <td>country-name</td><td><pre style="margin:0">Netherlands</pre></td>
+        </tr>
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+    </table>
+  </td>
+  <td valign="top">
+    
+      Output for "address":<br>
+      <pre class="formatting_example_textbox">Kerkstraat 10
+1234 AB Amsterdam
+Netherlands</pre>
+      
+      
+    
+  </td>
+</tr>
+<tr>
+  <td span="2">
+    &nbsp;
+  </td>
+</tr>
+
+      
+    </table>
+  </div>
 </div><div class="mdl-card mdl-shadow--2dp" style="width: 95%; margin: 8px">
   <div class="mdl-card__title">
     <h2 class="mdl-card__title-text">Details</h2>
@@ -1361,6 +1835,24 @@ Full name
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">name</span> =
+<span class="formatting_token">honorific-prefix</span><span class="formatting_token">given-name</span><span class="formatting_token">additional-name</span><span class="formatting_token">family-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">name</span> =<br>
+<span class="formatting_token">honorific-prefix</span><span class="formatting_token">given-name</span><span class="formatting_token">additional-name</span><span class="formatting_token">family-name-first</span><span class="formatting_token">family-name-conjunction</span><span class="formatting_token">family-name-second</span>
 </div>
 
 </div><h3 id="honorific-prefix">
@@ -1427,6 +1919,24 @@ Family name
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">family-name</span> =
+<span class="formatting_token">family-name-first</span><span class="formatting_token">family-name-conjunction</span><span class="formatting_token">family-name-second</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">family-name</span> =<br>
+<span class="formatting_token">family-name-first</span><span class="formatting_token">family-name-conjunction</span><span class="formatting_token">family-name-second</span>
 </div>
 
 </div><h3 id="family-name-first">
@@ -1515,6 +2025,24 @@ Address of a physical location - Artificial concept, not to be used in HTML
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">address</span> =
+<span class="formatting_token">street-address-alternative-1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">country-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">address</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token">unit</span><span class="formatting_token_separator"><br></span><span class="formatting_token">postal-code</span><span class="formatting_token_separator">␣</span><span class="formatting_token">locality1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">country-name</span>
+</div>
+
 </div><h3 id="street-address">
   <a href="#street-address">#</a>
   
@@ -1551,6 +2079,24 @@ Street address (street and location within the street)
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">street-address</span> =
+<span class="formatting_token">address-line1</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line2</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line3</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">address-line4</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">street-address</span> =<br>
+<span class="formatting_token">address-line1</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line2</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line3</span><span class="formatting_token_separator"><br></span><span class="formatting_token">address-line4</span>
 </div>
 
 </div><h3 id="address-line1">
@@ -1621,6 +2167,24 @@ Artificial concept, not to be used in HTML; this is a structured representation 
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">street-address-alternative-1</span> =
+<span class="formatting_token">building-location</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">street-address-alternative-1</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token">unit</span>
+</div>
+
 </div><h3 id="building-location">
   <a href="#building-location">#</a>
   
@@ -1647,6 +2211,24 @@ Name of a street and identifier for the building and the apartment
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">building-location</span> =
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building-and-unit</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">building-location</span> =<br>
+<span class="formatting_token">street</span><span class="formatting_token_separator">␣</span><span class="formatting_token">building</span><span class="formatting_token">unit</span>
 </div>
 
 </div><h3 id="street">
@@ -1686,6 +2268,24 @@ House number and unit
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">building-and-unit</span> =
+<span class="formatting_token">building</span><span class="formatting_token">unit</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">building-and-unit</span> =<br>
+<span class="formatting_token">building</span><span class="formatting_token">unit</span>
 </div>
 
 </div><h3 id="building">
@@ -1857,6 +2457,24 @@ Full name of credit card holder
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-name</span> =
+<span class="formatting_token">cc-given-name</span><span class="formatting_token">cc-additional-name</span><span class="formatting_token">cc-family-name</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-name</span> =<br>
+<span class="formatting_token">cc-given-name</span><span class="formatting_token">cc-additional-name</span><span class="formatting_token">cc-family-name</span>
+</div>
+
 </div><h3 id="cc-given-name">
   <a href="#cc-given-name">#</a>
   
@@ -1929,6 +2547,24 @@ Credit card expiration date in format MM/YY
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-exp-MMYY</span> =
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YY</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-exp-MMYY</span> =<br>
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YY</span>
+</div>
+
 </div><h3 id="cc-exp-MM">
   <a href="#cc-exp-MM">#</a>
   
@@ -1977,6 +2613,24 @@ Credit card expiration date in format MM/YYYY
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">cc-exp-MMYYYY</span> =
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YYYY</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">cc-exp-MMYYYY</span> =<br>
+<span class="formatting_token">cc-exp-MM</span><span class="formatting_token_separator">/</span><span class="formatting_token">cc-exp-YYYY</span>
 </div>
 
 </div><h3 id="cc-exp-YYYY">
@@ -2045,6 +2699,24 @@ Full telephone number
 </ul>
 </div>
 
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel</span> =
+<span class="formatting_token_prefix">+</span><span class="formatting_token">tel-country-code</span><span class="formatting_token">tel-national</span><span class="formatting_token_separator">-</span><span class="formatting_token">tel-extension</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel</span> =<br>
+<span class="formatting_token_prefix">+</span><span class="formatting_token">tel-country-code</span><span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span><span class="formatting_token_separator">-</span><span class="formatting_token">tel-extension</span>
+</div>
+
 </div><h3 id="tel-country-code">
   <a href="#tel-country-code">#</a>
   
@@ -2083,6 +2755,24 @@ Telephone number without the county code component, with a country-internal pref
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel-national</span> =
+<span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel-national</span> =<br>
+<span class="formatting_token">tel-area-code</span><span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
 </div>
 
 </div><h3 id="tel-area-code">
@@ -2124,6 +2814,24 @@ Telephone number without the country code and area code components
   </li>
 
 </ul>
+</div>
+
+
+
+
+
+
+
+<h4>Formatting:</h4>
+<div>
+<span class="formatting_token">tel-local</span> =
+<span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
+</div>
+
+<h5>Flattened formatting:</h5>
+<div>
+<span class="formatting_token">tel-local</span> =<br>
+<span class="formatting_token">tel-local-prefix</span><span class="formatting_token">tel-local-suffix</span>
 </div>
 
 </div><h3 id="tel-local-prefix">

--- a/model/countries/NL/NL-formatting-rules.yaml
+++ b/model/countries/NL/NL-formatting-rules.yaml
@@ -21,6 +21,7 @@ formatting-rules:
 
   building-and-unit:
   - building
+  - separator: "-"
   - unit
 
 examples:
@@ -43,7 +44,7 @@ examples:
     street: Kerkstraat
     building: 10
     unit: A
-    building-and-unit: 10A
+    building-and-unit: 10-A
     locality1: Amsterdam
     postal-code: 1234 AB
     country: NL
@@ -52,7 +53,7 @@ examples:
     address:
       show: true
       text: |
-        Kerkstraat 10A
+        Kerkstraat 10-A
         1234 AB Amsterdam
         Netherlands
 

--- a/model/countries/NL/NL-formatting-rules.yaml
+++ b/model/countries/NL/NL-formatting-rules.yaml
@@ -1,0 +1,76 @@
+formatting-rules:
+  address:
+  - street-address-alternative-1
+  - separator: "\n"
+  - postal-code
+  - separator: " "
+  - locality1
+  - separator: "\n"
+  - country-name
+  - skip: country  # redundant with country-name
+  - skip: street-address  # redundant with street-address-alternative-1
+  - skip: admin-area1 # not commonly used
+
+  street-address-alternative-1:
+  - building-location
+
+  building-location:
+  - street
+  - separator: " "
+  - building-and-unit
+
+  building-and-unit:
+  - building
+  - unit
+
+examples:
+- id: name
+  comment: |
+    This is an example of a name.
+  attributes:
+    given-name: Vincent
+    additional-name: Willem
+    family-name: van Gogh
+  output:
+    name:
+      show: true
+      text: Vincent Willem van Gogh
+
+- id: address
+  comment: |
+    This is an example of a full address in the Netherlands.
+  attributes:
+    street: Kerkstraat
+    building: 10
+    unit: A
+    building-and-unit: 10A
+    locality1: Amsterdam
+    postal-code: 1234 AB
+    country: NL
+    country-name: Netherlands
+  output:
+    address:
+      show: true
+      text: |
+        Kerkstraat 10A
+        1234 AB Amsterdam
+        Netherlands
+
+- id: address-without-unit
+  comment: |
+    This is an example of an address without indication of unit in the Netherlands.
+  attributes:
+    street: Kerkstraat
+    building: 10
+    building-and-unit: 10
+    locality1: Amsterdam
+    postal-code: 1234 AB
+    country: NL
+    country-name: Netherlands
+  output:
+    address:
+      show: true
+      text: |
+        Kerkstraat 10
+        1234 AB Amsterdam
+        Netherlands


### PR DESCRIPTION
This PR adds formatting rules for the Netherlands.
Sources:
- https://nl.wikipedia.org/wiki/Huisnummer
- https://nl.wikipedia.org/wiki/Adres_(woonplaats)