### PR TITLE
Update IN-formatting-rules.yaml

### DIFF
--- a/model/countries/IN/IN-formatting-rules.yaml
+++ b/model/countries/IN/IN-formatting-rules.yaml
@@ -23,9 +23,7 @@ formatting-rules:
   - locality2
 
   street-address-alternative-1:
-  - building-location
-  - separator: ", "
-  - locality2
+  - building-location-and-locality2
   - separator: ", "
   - landmark
 


### PR DESCRIPTION
Fix formatting rule for street-address-alternative-1. After this change the formatting will respect the order from the model hierarchy instead of accessing the leaves directly.