### PR TITLE
Support address lines 1&2

### DIFF
--- a/docs/model/IN.html
+++ b/docs/model/IN.html
@@ -1777,7 +1777,7 @@ Artificial concept, not to be used in HTML
 <h4>Formatting:</h4>
 <div>
 <span class="formatting_token">street-address-alternative-1</span> =
-<span class="formatting_token">building-location</span><span class="formatting_token_separator">,␣</span><span class="formatting_token">locality2</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">landmark</span>
+<span class="formatting_token">building-location-and-locality2</span><span class="formatting_token_separator">⏎</span><span class="formatting_token">landmark</span>
 </div>
 
 <h5>Flattened formatting:</h5>

--- a/model/countries/IN/IN-formatting-rules.yaml
+++ b/model/countries/IN/IN-formatting-rules.yaml
@@ -33,10 +33,10 @@ formatting-rules:
   - landmark
 
   street-address-alternative-1:
-  - building-location
-  - separator: ", "
-  - locality2
+  - building-location-and-locality2
   - separator: "\n"
   - landmark
+  - skip: building-location-and-landmark  # Not necessary.
+  - skip: landmark-and-locality2  # Not necessary.
 
   


### PR DESCRIPTION
This PR fixes the issue where the full street address count'd have been formatted if only the building_location_and_locality + landmark nodes existed.

The skip nodes are only needed because of the html generation script bug, which fails to output a file if only one of the "combined" nodes is present and the other are missing. The formatting rules itself will still be present for all synthesized nodes.